### PR TITLE
Fix for GitHub max description length

### DIFF
--- a/github/CHANGELOG.md
+++ b/github/CHANGELOG.md
@@ -1,5 +1,8 @@
 # GitHub Connector Change Log
 
+## 2022/4/26
+* Truncate repository description length to 256, the maximum supported length for OAA resource descrition.
+
 ## 2022/4/18
 * OS environment variable `OAA_TOKEN` changed to `VEZA_API_KEY`
 * Added new custom properties to extraction:

--- a/github/oaa_github.py
+++ b/github/oaa_github.py
@@ -228,8 +228,15 @@ class OAAGitHub():
 
     def discover_repo(self, repo):
         """ populate the OAA app with the access details for a given repo, takes in GitHub repo information dictionary"""
+
         # add the repository to the OAA model, will create a CustomResource for each repo
-        self.app.add_resource(name=repo['name'], resource_type="repository", description=repo['description'])
+        self.app.add_resource(name=repo['name'], resource_type="repository")
+
+        if repo['description'] and len(repo['description']) > 256:
+            # OAA description max length is 256, GitHub's description could be longer, truncate
+            self.app.resources[repo['name']].description = repo['description'][:255]
+        else:
+            self.app.resources[repo['name']].description = repo['description']
 
         # get the full name of the repository (oprg/repo) to make getting the repo details easier
         full_name = repo['full_name']


### PR DESCRIPTION
GitHub repo descriptions can exceed the maxium OAA resource description
length of 256 characters. Truncate repo description if it exceeds 256
characters.