### PR TITLE
oaaclient class changes

### DIFF
--- a/github/oaa_github.py
+++ b/github/oaa_github.py
@@ -1,6 +1,6 @@
 #!env python3
-from oaaclient.client import OAAClient, OAAClientError, OAAPermission
-from oaaclient.templates import CustomApplication, CustomPermission, OAAPropertyType
+from oaaclient.client import OAAClient, OAAClientError
+from oaaclient.templates import CustomApplication, CustomPermission, OAAPermission, OAAPropertyType
 from pprint import pprint
 from requests import HTTPError
 from time import time

--- a/gitlab/oaa_gitlab.py
+++ b/gitlab/oaa_gitlab.py
@@ -1,7 +1,7 @@
 #!env python3
 
-from oaaclient.client import OAAClient, OAAClientError, OAAPermission
-from oaaclient.templates import CustomApplication, CustomResource, OAAPropertyType
+from oaaclient.client import OAAClient, OAAClientError
+from oaaclient.templates import CustomApplication, CustomResource, OAAPermission, OAAPropertyType
 from requests import HTTPError
 import argparse
 import logging

--- a/jira/oaa_jira.py
+++ b/jira/oaa_jira.py
@@ -1,7 +1,6 @@
 #!env python3
-from oaaclient.client import OAAClient, OAAClientError, OAAPermission, OAAIdentityType
-from oaaclient.templates import CustomApplication, CustomPermission, CustomResource, OAAPropertyType
-from pprint import pprint
+from oaaclient.client import OAAClient, OAAClientError
+from oaaclient.templates import CustomApplication, OAAPermission, OAAPropertyType
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import HTTPError
 import argparse

--- a/looker/looker_permissions.py
+++ b/looker/looker_permissions.py
@@ -1,4 +1,4 @@
-from oaaclient.client import OAAPermission
+from oaaclient.templates import OAAPermission
 
 looker_permission_definitions = {
     "access_data": [OAAPermission.DataRead],

--- a/looker/oaa_looker.py
+++ b/looker/oaa_looker.py
@@ -1,7 +1,7 @@
 #!env python3
 from looker_permissions import looker_permission_definitions
-from oaaclient.client import OAAClient, OAAClientError, OAAPermission
-from oaaclient.templates import CustomApplication, CustomResource, OAAPropertyType
+from oaaclient.client import OAAClient, OAAClientError
+from oaaclient.templates import CustomApplication, CustomResource, OAAPermission, OAAPropertyType
 from requests import HTTPError
 from urllib.parse import urlparse
 import argparse

--- a/oaaclient/CHANGELOG.md
+++ b/oaaclient/CHANGELOG.md
@@ -1,8 +1,11 @@
 # OAA Client Change Log
 
+## 2022/05/03
+* Moved `OAAPermission` and `OAAIdentityType` enums to `templates`, any import statements will need to be updated
+
 ## 2022/04/26
 *   Added `CustomIdPUser.set_source_identity` for setting the source identity of a user. Also added new enum
-    `IdPProviderType` for supported IdP providers. 
+    `IdPProviderType` for supported IdP providers.
 
 ## 2022/4/18
 * `CookiePermission` has been renamed to `OAAPermission`, any references will need to be updated.

--- a/oaaclient/README.md
+++ b/oaaclient/README.md
@@ -10,8 +10,8 @@ The `oaaclient` SDK consists of two main components:
 
 ### Sample Workflow
 ```python
-from oaaclient.client import OAAClient, OAAPermission
-from oaaclient.templates import CustomApplication
+from oaaclient.client import OAAClient
+from oaaclient.templates import CustomApplication, OAAPermission
 
 # creates a connection class to communicate with Veza
 veza_con = OAAClient(url=veza_url, token=veza_api_key)

--- a/oaaclient/src/client.py
+++ b/oaaclient/src/client.py
@@ -18,27 +18,6 @@ class OAAClientError(Exception):
         self.details = details
 
 
-class OAAPermission(str, Enum):
-    """ Canonical permissions support by Veza Authorization Framework """
-    DataRead = "DataRead"
-    DataWrite = "DataWrite"
-    DataCreate = "DataCreate"
-    DataDelete = "DataDelete"
-    MetadataRead = "MetadataRead"
-    MetadataWrite = "MetadataWrite"
-    MetadataCreate = "MetadataCreate"
-    MetadataDelete = "MetadataDelete"
-    NonData = "NonData"
-
-
-class OAAIdentityType(str, Enum):
-    """ types of identities for permission mapping """
-    LocalUser = "local_user"
-    LocalGroup = "local_group"
-    LocalRole = "local_role"
-    IdP = "idp"
-
-
 class OAAClient():
     def __init__(self, url, api_key: str = None, username: str = None, token: str = None):
         if not re.match(r"^https:\/\/.*", url):

--- a/oaaclient/src/templates.py
+++ b/oaaclient/src/templates.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 from typing import Optional
 from enum import Enum
-from oaaclient.client import OAAPermission, OAAIdentityType
 import json
 import re
 
@@ -12,6 +11,27 @@ class OAATemplateException(Exception):
     def __init__(self, message):
         self.message = message
         super().__init__(self.message)
+
+
+class OAAPermission(str, Enum):
+    """ Canonical permissions support by Veza Authorization Framework """
+    DataRead = "DataRead"
+    DataWrite = "DataWrite"
+    DataCreate = "DataCreate"
+    DataDelete = "DataDelete"
+    MetadataRead = "MetadataRead"
+    MetadataWrite = "MetadataWrite"
+    MetadataCreate = "MetadataCreate"
+    MetadataDelete = "MetadataDelete"
+    NonData = "NonData"
+
+
+class OAAIdentityType(str, Enum):
+    """ types of identities for permission mapping """
+    LocalUser = "local_user"
+    LocalGroup = "local_group"
+    LocalRole = "local_role"
+    IdP = "idp"
 
 
 class Provider():

--- a/oaaclient/tests/generate_app.py
+++ b/oaaclient/tests/generate_app.py
@@ -1,5 +1,4 @@
-from oaaclient.client import OAAPermission
-from oaaclient.templates import CustomApplication, Tag, OAAPropertyType
+from oaaclient.templates import CustomApplication, Tag, OAAPermission, OAAPropertyType
 
 
 def generate_app():

--- a/oaaclient/tests/test_custom_application.py
+++ b/oaaclient/tests/test_custom_application.py
@@ -2,8 +2,7 @@ import pytest
 import json
 import os
 
-from oaaclient.client import OAAPermission, OAAIdentityType
-from oaaclient.templates import CustomApplication, CustomPermission, OAATemplateException, Tag, OAAPropertyType
+from oaaclient.templates import CustomApplication, CustomPermission, OAAPermission, OAAIdentityType, OAATemplateException, Tag, OAAPropertyType
 from generate_app import generate_app, GENERATED_APP_PAYLOAD
 
 

--- a/salesforce/oaa_salesforce.py
+++ b/salesforce/oaa_salesforce.py
@@ -1,6 +1,6 @@
 #!env python3
-from oaaclient.client import OAAClient, OAAClientError, OAAPermission, OAAIdentityType
-from oaaclient.templates import CustomApplication, CustomPermission, CustomResource
+from oaaclient.client import OAAClient, OAAClientError
+from oaaclient.templates import CustomApplication, OAAPermission
 from requests.exceptions import HTTPError
 from urllib.parse import urlparse
 import argparse

--- a/samples/sample-app.py
+++ b/samples/sample-app.py
@@ -12,8 +12,8 @@ export VEZA_URL="https://myveza.vezacloud.com"
 ```
 """
 
-from oaaclient.client import OAAClient, OAAClientError, OAAPermission
-from oaaclient.templates import CustomApplication
+from oaaclient.client import OAAClient, OAAClientError
+from oaaclient.templates import CustomApplication, OAAPermission
 import os
 import sys
 

--- a/zendesk/oaa_zendesk.py
+++ b/zendesk/oaa_zendesk.py
@@ -1,7 +1,7 @@
 #!env python3
 
-from oaaclient.client import OAAClient, OAAClientError, OAAPermission
-from oaaclient.templates import CustomApplication, OAAPropertyType
+from oaaclient.client import OAAClient, OAAClientError
+from oaaclient.templates import CustomApplication, OAAPermission, OAAPropertyType
 from oaaclient.utils import log_arg_error
 from requests import HTTPError
 import argparse


### PR DESCRIPTION
Moved `OAAPermission` and `OAAIdentityType` enums from `client.py` to `templates.py`
to avoid future circular import issues.

Updated import statements for existing connectors to reflect change.