### PR TITLE
Remove duplicate permissions from roles

### DIFF
--- a/oaaclient/CHANGELOG.md
+++ b/oaaclient/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OAA Client Change Log
 
+## 2022/09/28
+
+* Update to LocalRole payload logic to remove duplicate permissions 
+
 ## 2022/09/20
 
 * Increase timeout on delete API operations

--- a/oaaclient/src/templates.py
+++ b/oaaclient/src/templates.py
@@ -1060,7 +1060,7 @@ class LocalRole():
         """
         response = {}
         response['name'] = self.name
-        response['permissions'] = self.permissions
+        response['permissions'] = unique_strs(self.permissions)
         response['tags'] = [tag.__dict__ for tag in self.tags]
         response['custom_properties'] = self.properties
         if self.unique_id:
@@ -1873,3 +1873,31 @@ def append_helper(base, addition):
         base.append(addition)
 
     return base
+
+def unique_strs(input: list) -> list:
+    """Returns a list of unique strings from input list case insensitive
+
+    Returns the unique list of strings from input list in a case insensitive manner.
+    For duplicate strings with different cast (e.g. "STRING" and "string") the case of
+    the first occurrence is returned.
+
+    Args:
+        input (list): list of strings
+
+    Returns:
+        list: list of unique strings
+    """
+
+    if not isinstance(input, list):
+        raise ValueError("input must be list")
+
+    unique = []
+    seen = []
+    for e in input:
+        if not isinstance(e, str):
+            raise ValueError("input elements must be string")
+        if e.lower() not in seen:
+            seen.append(e.lower())
+            unique.append(e)
+
+    return unique

--- a/oaaclient/tests/test_template_functions.py
+++ b/oaaclient/tests/test_template_functions.py
@@ -1,0 +1,18 @@
+"""
+Copyright 2022 Veza Technologies Inc.
+
+Use of this source code is governed by the MIT
+license that can be found in the LICENSE file or at
+https://opensource.org/licenses/MIT.
+"""
+
+from oaaclient.templates import unique_strs
+
+def test_unique_strs():
+    input = ["str1", "str2", "str3"]
+    assert unique_strs(input) == input
+
+    input = ["STR1", "STR1", "STR2", "str3", "str1"]
+    assert unique_strs(input) == ["STR1", "STR2", "str3"]
+
+    assert unique_strs([]) == []


### PR DESCRIPTION
Remove any duplicate permissions added to a LocalRole before payload is generated.