### PR TITLE
Fix for Jira connector description length

### DIFF
--- a/jira/CHANGELOG.md
+++ b/jira/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Jira Connector Change Log
+
+## 2022/10/11
+* Fix for issue with long descriptions. Project descriptions are now truncated to 256 characters if needed.
+
 ## 2022/9/20
 * Fix for possible issue with plugin project permissions
 * Publish Custom Application name will now contain the Jira instance URL

--- a/jira/oaa_jira.py
+++ b/jira/oaa_jira.py
@@ -248,6 +248,10 @@ def load_projects(jira_con, oaa_app):
     project_key         = project.get("key")
     project_name        = project.get("name")
 
+    if project_description and len(project_description) > 256:
+      # truncate project description to max length of 256
+      project_description = project_description[:256]
+
     log.info(f"Loading project {project_name}")
 
     if project_name not in oaa_app.resources:


### PR DESCRIPTION
Truncate Jira project descriptions to max description length.