### PR TITLE
Updates to OAAClient

### DIFF
--- a/oaaclient/CHANGELOG.md
+++ b/oaaclient/CHANGELOG.md
@@ -1,5 +1,20 @@
 # OAA Client Change Log
 
+## 2022/10/26
+* Improvements for group `unique_id` handling of non-string values.
+* Check for user or group not already a member before adding to group
+
+## 2022/10/17
+* Added support for resource unique identifier separte from `name`.
+  * `add_resource` and `add_sub_resource` functions allow new optional property `unique_id`
+  * When `unique_id` is provided it will serve as the key for the resource in the `.resources` and `.sub_resources` dictionaries
+  * To use `unique_id` all resources must use `unique_id`
+  * When using `unique_id` name does not need to be unique for a resource
+
+## 2022/10/14
+* Optimization to payload size for unset entities
+* Fix for boolean local user properties in payload
+
 ## 2022/09/28
 
 * Update to LocalRole payload logic to remove duplicate permissions 

--- a/oaaclient/tests/generate_app.py
+++ b/oaaclient/tests/generate_app.py
@@ -76,6 +76,8 @@ def generate_app():
         user.set_property("peers", username_list)
         user.set_property("birthday", "2000-01-01T00:00:00.000Z")
 
+    app.local_users["marry"].is_active = False
+
     # groups
     app.property_definitions.define_local_group_property("group_id", OAAPropertyType.NUMBER)
     group1 = app.add_local_group("group1")
@@ -224,7 +226,7 @@ GENERATED_APP_PAYLOAD = """
             "group1",
             "group2"
           ],
-          "is_active": true,
+          "is_active": false,
           "created_at": "2001-01-01T00:00:00.000Z",
           "last_login_at": "2002-02-01T00:00:00.000Z",
           "deactivated_at": "2003-03-01T00:00:00.000Z",
@@ -481,10 +483,6 @@ GENERATED_APP_PAYLOAD = """
       ]
     },
     {
-      "identity": "sue",
-      "identity_type": "local_user"
-    },
-    {
       "identity": "rob",
       "identity_type": "local_user",
       "application_permissions": [
@@ -503,10 +501,6 @@ GENERATED_APP_PAYLOAD = """
       ]
     },
     {
-      "identity": "group1",
-      "identity_type": "local_group"
-    },
-    {
       "identity": "group2",
       "identity_type": "local_group",
       "role_assignments": [
@@ -519,10 +513,6 @@ GENERATED_APP_PAYLOAD = """
           ]
         }
       ]
-    },
-    {
-      "identity": "group3",
-      "identity_type": "local_group"
     }
   ]
 }

--- a/oaaclient/tests/generate_app_id_mapping.py
+++ b/oaaclient/tests/generate_app_id_mapping.py
@@ -6,6 +6,7 @@ license that can be found in the LICENSE file or at
 https://opensource.org/licenses/MIT.
 """
 
+from enum import unique
 from oaaclient.templates import CustomApplication, Tag, OAAPermission, OAAPropertyType
 
 def generate_app_id_mapping():
@@ -111,21 +112,21 @@ def generate_app_id_mapping():
     app.property_definitions.define_resource_property("thing", "peers", OAAPropertyType.STRING_LIST)
     app.property_definitions.define_resource_property("thing", "publish_date", OAAPropertyType.TIMESTAMP)
 
-    thing1 = app.add_resource("thing1", resource_type="thing", description="thing1")
+    thing1 = app.add_resource("thing1", unique_id="t1", resource_type="thing", description="thing1")
     thing1.set_property("private", False)
     thing1.set_property("unique_id", 1)
     thing1.set_property("hair_color", "blue")
     thing1.set_property("peers", ["thing2", "thing3"])
     thing1.set_property("publish_date", "1959-03-12T00:00:00.000Z")
 
-    thing2 = app.add_resource("thing2", resource_type="thing")
+    thing2 = app.add_resource("thing2", unique_id="t2", resource_type="thing")
     thing2.set_property("private", False)
     thing2.set_property("unique_id", 2)
     thing2.set_property("hair_color", "blue")
     thing2.set_property("peers", ["thing2", "thing3"])
     thing2.set_property("publish_date", "1959-03-12T00:00:00.000Z")
 
-    cog1 = thing2.add_sub_resource("cog1", resource_type="cog")
+    cog1 = thing2.add_sub_resource("cog1", unique_id="c1", resource_type="cog")
     cog1.add_resource_connection("service_account@some-project.iam.gserviceaccount.com", "GoogleCloudServiceAccount")
 
     # authorizations
@@ -313,6 +314,7 @@ GENERATED_APP_ID_MAPPINGS_PAYLOAD = """
       },
       "resources": [
         {
+          "id": "t1",
           "name": "thing1",
           "resource_type": "thing",
           "description": "thing1",
@@ -328,10 +330,12 @@ GENERATED_APP_ID_MAPPINGS_PAYLOAD = """
           }
         },
         {
+          "id": "t2",
           "name": "thing2",
           "resource_type": "thing",
           "sub_resources": [
             {
+              "id": "c1",
               "name": "cog1",
               "resource_type": "cog",
               "connections": [
@@ -409,10 +413,6 @@ GENERATED_APP_ID_MAPPINGS_PAYLOAD = """
   ],
   "identity_to_permissions": [
     {
-      "identity": "1234",
-      "identity_type": "local_user"
-    },
-    {
       "identity": "1235",
       "identity_type": "local_user",
       "role_assignments": [
@@ -431,8 +431,8 @@ GENERATED_APP_ID_MAPPINGS_PAYLOAD = """
         {
           "application": "pytest unique id app",
           "resources": [
-            "thing2",
-            "thing2.cog1"
+            "t2",
+            "t2.c1"
           ],
           "permission": "view"
         }
@@ -450,15 +450,11 @@ GENERATED_APP_ID_MAPPINGS_PAYLOAD = """
         {
           "application": "pytest unique id app",
           "resources": [
-            "thing1"
+            "t1"
           ],
           "permission": "manage"
         }
       ]
-    },
-    {
-      "identity": "g1",
-      "identity_type": "local_group"
     },
     {
       "identity": "g2",
@@ -469,14 +465,10 @@ GENERATED_APP_ID_MAPPINGS_PAYLOAD = """
           "role": "r2",
           "apply_to_application": false,
           "resources": [
-            "thing1"
+            "t1"
           ]
         }
       ]
-    },
-    {
-      "identity": "g3",
-      "identity_type": "local_group"
     }
   ]
 }

--- a/oaaclient/tests/test_custom_application.py
+++ b/oaaclient/tests/test_custom_application.py
@@ -445,19 +445,6 @@ CUSTOM_PROPERTIES_PAYLOAD = """
       "resource_types": []
     }
   ],
-  "identity_to_permissions": [
-    {
-      "identity": "bob",
-      "identity_type": "local_user"
-    },
-    {
-      "identity": "sue",
-      "identity_type": "local_user"
-    },
-    {
-      "identity": "admins",
-      "identity_type": "local_group"
-    }
-  ]
+  "identity_to_permissions": []
 }
 """


### PR DESCRIPTION
* Improvements for group `unique_id` handling of non-string values.
* Check for user or group not already a member before adding to group

* Added support for resource unique identifier separte from `name`.
  * `add_resource` and `add_sub_resource` functions allow new optional property `unique_id`
  * When `unique_id` is provided it will serve as the key for the resource in the `.resources` and `.sub_resources` dictionaries
  * To use `unique_id` all resources must use `unique_id`
  * When using `unique_id` name does not need to be unique for a resource

* Optimization to payload size for unset entities
* Fix for boolean local user properties in payload