### PR TITLE
Fix for user discovery

### DIFF
--- a/slack/CHANGELOG.md
+++ b/slack/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Slack OAA Connector Change Log
 
+## 2022/11/03
+* Fix for user discovery and parsing group memberships
+
 ## 2022/10/03
 * Initial release


### PR DESCRIPTION
Added protection when parsing group memberships that user ID exists before adding group.

Also fixed possible issue in user discovery that could have caused us to skip some users who didn't have a name field set.