### PR TITLE
Fix for Bitbucket collaborators

### DIFF
--- a/bitbucket-cloud/CHANGELOG.md
+++ b/bitbucket-cloud/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Bitbucket Cloud Changelog
+## 2023/1/20
+* Add support for `collaborator` workspace permission
+
 ## 2023/1/19
 * Updated Docker image base to `python:3.10-alpine`
 

--- a/bitbucket-cloud/oaa_bitbucket.py
+++ b/bitbucket-cloud/oaa_bitbucket.py
@@ -88,6 +88,10 @@ class OAABitbucket():
                 added_on = e["added_on"]
                 new_user.created_at = added_on
 
+            if not e['permission'] in self.app.custom_permissions:
+                log.error(f"Unknown workspace permission for user: {e['permission']}")
+                continue
+
             new_user.add_permission(e['permission'], apply_to_application=True)
         return
 
@@ -326,6 +330,7 @@ class OAABitbucket():
         """
 
         self.app.add_custom_permission("owner",  permissions=[OAAPermission.DataRead, OAAPermission.DataWrite, OAAPermission.DataDelete])
+        self.app.add_custom_permission("collaborator",  permissions=[OAAPermission.DataRead, OAAPermission.DataWrite])
         self.app.add_custom_permission("member",  permissions=[OAAPermission.DataRead])
 
         self.app.add_custom_permission("admin", apply_to_sub_resources=True, permissions=[OAAPermission.DataRead, OAAPermission.DataWrite, OAAPermission.DataDelete])


### PR DESCRIPTION
Adds in a permission definition for the workspace role of collaborator